### PR TITLE
Transpile to es5

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -35,3 +35,4 @@ jspm_packages
 
 # Optional REPL history
 .node_repl_history
+dist

--- a/.npmignore
+++ b/.npmignore
@@ -1,0 +1,1 @@
+index.js

--- a/package.json
+++ b/package.json
@@ -1,12 +1,14 @@
 {
   "name": "camelobj",
-  "version": "0.0.4",
+  "version": "0.0.5",
   "description": "Changes all properties to camel case",
-  "main": "index.js",
+  "main": "./dist/index.js",
   "scripts": {
     "test": "istanbul cover tape test/**/*.spec.js",
     "test-dev": "tape test/**/*.spec.js | tap-spec || echo ''",
-    "tdd": "nodemon -q -x 'npm run test-dev'"
+    "tdd": "nodemon -q -x 'npm run test-dev'",
+    "build": "babel index.js --presets babel-preset-es2015 --out-dir dist",
+    "prepublish": "npm run build"
   },
   "engines": {
     "node": ">=6.2.0"
@@ -14,6 +16,8 @@
   "author": "Gustavo Ortiz @codingpains",
   "license": "MIT",
   "devDependencies": {
+    "babel-cli": "^6.24.1",
+    "babel-preset-es2015": "^6.24.1",
     "eslint": "^3.1.0",
     "istanbul": "^0.4.4",
     "nodemon": "^1.9.2",


### PR DESCRIPTION
When running `webpack -p` on my project, it failed because this module was written in ES6 and provided no ES5 option. Now it should transpile automatically when publishing.